### PR TITLE
#10 / feat: add theme + button component props

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,17 @@
 import { FC } from 'react';
 import { ReactQueryProvider, RecoilProvider } from './providers';
 import { RouterProvider } from './router';
+import { ThemeProvider } from 'styled-components';
+import { Theme } from './styles';
 
 export const App: FC = () => {
   return (
     <>
       <RecoilProvider>
         <ReactQueryProvider>
-          <RouterProvider />
+          <ThemeProvider theme={Theme}>
+            <RouterProvider />
+          </ThemeProvider>
         </ReactQueryProvider>
       </RecoilProvider>
     </>

--- a/src/pages/CreatePost/CreatePost.tsx
+++ b/src/pages/CreatePost/CreatePost.tsx
@@ -26,7 +26,7 @@ export const CreatePost = () => {
       <Button
         onClick={onClickHandleModal}
         label="게시물 작성"
-        $buttonTheme="filled"
+        $buttonTheme="pink"
         size="small"
       />
     </>

--- a/src/pages/CreatePost/const.ts
+++ b/src/pages/CreatePost/const.ts
@@ -5,7 +5,7 @@ export const MODAL_ATTRIBUTES = {
 };
 
 export const BUTTON_CONFIGS = {
-  [MODAL_ATTRIBUTES.UPLOAD]: { label: '확인', theme: 'filled' },
-  [MODAL_ATTRIBUTES.DELETE]: { label: '삭제', theme: 'filled' },
-  [MODAL_ATTRIBUTES.EDIT]: { label: '수정', theme: 'filled' },
+  [MODAL_ATTRIBUTES.UPLOAD]: { label: '확인', theme: 'pink' },
+  [MODAL_ATTRIBUTES.DELETE]: { label: '삭제', theme: 'pink' },
+  [MODAL_ATTRIBUTES.EDIT]: { label: '수정', theme: 'pink' },
 };

--- a/src/providers/reactQuery/ReactQueryProvider.tsx
+++ b/src/providers/reactQuery/ReactQueryProvider.tsx
@@ -1,13 +1,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FC, ReactNode } from 'react';
 
-type IReactQueryProviderProps = {
+type ReactQueryProviderProps = {
   children: ReactNode;
 };
 
 const queryClient = new QueryClient();
 
-export const ReactQueryProvider: FC<IReactQueryProviderProps> = ({
+export const ReactQueryProvider: FC<ReactQueryProviderProps> = ({
   children,
 }) => {
   return (

--- a/src/providers/recoil/RecoilProvider.tsx
+++ b/src/providers/recoil/RecoilProvider.tsx
@@ -5,10 +5,10 @@ export interface IRecoilContext {}
 
 export const RecoilContext = createContext<IRecoilContext | null>(null);
 
-type IRecoilProviderProps = {
+type RecoilProviderProps = {
   children: ReactNode;
 };
 
-export const RecoilProvider: FC<IRecoilProviderProps> = ({ children }) => {
+export const RecoilProvider: FC<RecoilProviderProps> = ({ children }) => {
   return <RecoilRoot>{children}</RecoilRoot>;
 };

--- a/src/shared/Button/Button.tsx
+++ b/src/shared/Button/Button.tsx
@@ -1,9 +1,15 @@
 import { FC } from 'react';
 import { ButtonStyle, ButtonWrapper } from './ButtonStyle';
 
-type IButtonProps = {
+type ButtonProps = {
   label: string;
-  $buttonTheme: 'filled' | 'empty' | 'gray';
+  $buttonTheme:
+    | 'pink'
+    | 'emptyBlue'
+    | 'gray'
+    | 'blue'
+    | 'emptyGray'
+    | 'emptyPink';
   size: string;
   $bold?: boolean;
   onClick?: () => void;
@@ -11,13 +17,14 @@ type IButtonProps = {
 
 /***
  * @param {string} label - 버튼 이름
- * @param {string} $buttonTheme - filled / empty / gray
+ * @param {string} $buttonTheme - pink / emptyBlue / gray / blue / emptyGray / emptyPink
  * @param {string} size - small / large
- * @param {string} $bold - [선택] 넣을 경우 굵은 글씨
+ * @param {boolean} $bold - [선택] 넣을 경우 굵은 글씨
+ * @param {function} onClick
  */
-export const Button: FC<IButtonProps> = ({
+export const Button: FC<ButtonProps> = ({
   label = 'label',
-  $buttonTheme = 'filled',
+  $buttonTheme = 'pink',
   size = 'small',
   $bold = false,
   onClick,

--- a/src/shared/Button/ButtonStyle.tsx
+++ b/src/shared/Button/ButtonStyle.tsx
@@ -1,71 +1,8 @@
-import { ButtonHTMLAttributes } from 'react';
-import { styled, css, DefaultTheme } from 'styled-components';
+import { styled, css } from 'styled-components';
+import { ButtonStyleProps } from './type';
+import { $buttonTheme } from './buttonTheme';
 
-interface IButtonStyleProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  $buttonTheme: keyof typeof $buttonTheme;
-  theme: Mytheme;
-  size: string;
-  $bold?: boolean;
-}
-
-interface Mytheme extends DefaultTheme {
-  filled: {
-    backgroundColor: string;
-    color: string;
-    border: string;
-    hover: {
-      backgroundColor: string;
-    };
-  };
-
-  empty: {
-    backgroundColor: string;
-    color: string;
-    border: string;
-    hover: {
-      backgroundColor: string;
-    };
-  };
-
-  gray: {
-    backgroundColor: string;
-    color: string;
-    border: string;
-    hover: {
-      backgroundColor: string;
-    };
-  };
-}
-
-const $buttonTheme = {
-  filled: {
-    backgroundColor: '#FF005E',
-    color: '#fff',
-    border: '1px solid transparent',
-    hover: {
-      backgroundColor: '#ff478a',
-    },
-  },
-  empty: {
-    backgroundColor: '#fff',
-    color: 'black',
-    border: '1px solid rgba(0, 0, 0, 0.25)',
-    hover: {
-      backgroundColor: '#ececec',
-    },
-  },
-
-  gray: {
-    backgroundColor: '#D9D9D9',
-    color: '#A2A2A2',
-    border: '1px solid transparent',
-    hover: {
-      backgroundColor: '#dfdfdf',
-    },
-  },
-};
-
-export const ButtonStyle = styled.button<IButtonStyleProps>`
+export const ButtonStyle = styled.button<ButtonStyleProps>`
   display: flex;
   flex: 1;
   text-decoration: none;
@@ -76,20 +13,18 @@ export const ButtonStyle = styled.button<IButtonStyleProps>`
     border-color 0.1s;
   cursor: pointer;
   align-items: center;
-  padding-top: ${(props) => (props.size === 'large' ? '22.25px' : '15.75px')};
-  padding-bottom: ${(props) =>
-    props.size === 'large' ? '22.25px' : '15.75px'};
+  padding-top: ${(props) => (props.size === 'large' ? '16px' : '12px')};
+  padding-bottom: ${(props) => (props.size === 'large' ? '16px' : '12px')};
   padding-left: 16px;
   padding-right: 16px;
   box-sizing: border-box;
-  border: 1px solid transparent;
   font: inherit;
   border-radius: 11px;
   background-color: ${(props) =>
     $buttonTheme[props.$buttonTheme].backgroundColor};
   color: ${(props) => $buttonTheme[props.$buttonTheme].color};
   font-size: ${(props) => (props.size === 'large' ? '18px' : '14px')};
-  font-weight: ${(props) => (props.$bold ? '600' : '400')};
+  font-weight: ${(props) => (props.$bold ? '700' : '400')};
   border: ${(props) => $buttonTheme[props.$buttonTheme].border};
   ${(props) => css`
     &:hover,

--- a/src/shared/Button/buttonTheme.ts
+++ b/src/shared/Button/buttonTheme.ts
@@ -1,0 +1,56 @@
+import { Theme } from '../../styles';
+
+export const $buttonTheme = {
+  pink: {
+    backgroundColor: Theme.colors.pink,
+    color: Theme.colors.white,
+    border: '1px solid transparent',
+    hover: {
+      backgroundColor: '#ff478a',
+    },
+  },
+  emptyBlue: {
+    backgroundColor: Theme.colors.white,
+    color: Theme.colors.blue,
+    border: `2px solid ${Theme.colors.blue}`,
+    hover: {
+      backgroundColor: '#eaeffe',
+    },
+  },
+
+  gray: {
+    backgroundColor: Theme.colors.gray,
+    color: Theme.colors.black,
+    border: '1px solid transparent',
+    hover: {
+      backgroundColor: '#dfdfdf',
+    },
+  },
+
+  blue: {
+    backgroundColor: Theme.colors.blue,
+    color: Theme.colors.white,
+    border: '1px solid transparent',
+    hover: {
+      backgroundColor: '#789bfb',
+    },
+  },
+
+  emptyGray: {
+    backgroundColor: Theme.colors.white,
+    color: Theme.colors.black,
+    border: `2px solid ${Theme.colors.gray}`,
+    hover: {
+      backgroundColor: '#efefef',
+    },
+  },
+
+  emptyPink: {
+    backgroundColor: Theme.colors.white,
+    color: Theme.colors.pink,
+    border: `2px solid ${Theme.colors.gray}`,
+    hover: {
+      backgroundColor: '#efefef',
+    },
+  },
+};

--- a/src/shared/Button/type.ts
+++ b/src/shared/Button/type.ts
@@ -1,0 +1,67 @@
+import { ButtonHTMLAttributes } from 'react';
+import { DefaultTheme } from 'styled-components';
+import { $buttonTheme } from './buttonTheme';
+
+export interface ButtonStyleProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  $buttonTheme: keyof typeof $buttonTheme;
+  theme: Mytheme;
+  size: string;
+  $bold?: boolean;
+}
+
+export interface Mytheme extends DefaultTheme {
+  pink: {
+    backgroundColor: string;
+    color: string;
+    border: string;
+    hover: {
+      backgroundColor: string;
+    };
+  };
+
+  emptyBlue: {
+    backgroundColor: string;
+    color: string;
+    border: string;
+    hover: {
+      backgroundColor: string;
+    };
+  };
+
+  gray: {
+    backgroundColor: string;
+    color: string;
+    border: string;
+    hover: {
+      backgroundColor: string;
+    };
+  };
+
+  blue: {
+    backgroundColor: string;
+    color: string;
+    border: string;
+    hover: {
+      backgroundColor: string;
+    };
+  };
+
+  emptyGray: {
+    backgroundColor: string;
+    color: string;
+    border: string;
+    hover: {
+      backgroundColor: string;
+    };
+  };
+
+  emptyPink: {
+    backgroundColor: string;
+    color: string;
+    border: string;
+    hover: {
+      backgroundColor: string;
+    };
+  };
+}

--- a/src/shared/PostModal/PostModal.tsx
+++ b/src/shared/PostModal/PostModal.tsx
@@ -22,7 +22,7 @@ export const PostModal: FC<ModalProps> = ({ attribute, onClick }) => {
           {buttonConfig && (
             <Button
               label={buttonConfig.label}
-              $buttonTheme="filled"
+              $buttonTheme="pink"
               size="large"
             />
           )}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,1 +1,2 @@
 export * from './GlobalStyle';
+export * from './theme';

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,19 @@
+interface ThemeProps {
+  colors: {
+    pink: string;
+    gray: string;
+    blue: string;
+    white: string;
+    black: string;
+  };
+}
+
+export const Theme: ThemeProps = {
+  colors: {
+    pink: '#FF005E',
+    gray: '#D9D9D9',
+    blue: '#5782FA',
+    white: '#FEFEFE',
+    black: '#14171F',
+  },
+};


### PR DESCRIPTION
### work description

- add theme provider with color definitions
- add new button theme props
- separate types, theme, styled-components
- update string value of specific prop
- rename type prefixes
